### PR TITLE
FIX: broken link on homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -57,7 +57,7 @@
         <h1 class="mb-3 text-center text-lg-left">What is <span class="text-primary"><strong>ChartMuseum</strong></span>?</h1>
         <p class="lead--lg">
           ChartMuseum is an open-source
-          <a href="https://github.com/kubernetes/helm/blob/master/docs/chart_repository.md" target="_blank">Helm Chart Repository</a> written in Go (Golang), with support for cloud storage backends, including
+          <a href="https://helm.sh/docs/topics/chart_repository" target="_blank">Helm Chart Repository</a> written in Go (Golang), with support for cloud storage backends, including
           <a href="https://cloud.google.com/storage" target="_blank">Google Cloud Storage</a>,
           <a href="https://aws.amazon.com/s3" target="_blank">Amazon S3</a>,
           <a href="https://azure.microsoft.com/en-us/services/storage/blobs" target="_blank">Microsoft Azure Blob Storage</a>,

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -12,7 +12,7 @@
         <h1 class="mb-3 text-center text-lg-left">What is <span class="text-primary"><strong>ChartMuseum</strong></span>?</h1>
         <p class="lead--lg">
           ChartMuseum is an open-source
-          <a href="https://github.com/kubernetes/helm/blob/master/docs/chart_repository.md" target="_blank">Helm Chart Repository</a> server written in Go (Golang), with support for cloud storage backends, including
+          <a href="https://helm.sh/docs/topics/chart_repository" target="_blank">Helm Chart Repository</a> server written in Go (Golang), with support for cloud storage backends, including
           <a href="https://cloud.google.com/storage" target="_blank">Google Cloud Storage</a>,
           <a href="https://aws.amazon.com/s3" target="_blank">Amazon S3</a>,
           <a href="https://azure.microsoft.com/en-us/services/storage/blobs" target="_blank">Microsoft Azure Blob Storage</a>,


### PR DESCRIPTION
https://github.com/kubernetes/helm/blob/master/docs/chart_repository.md is a dead link. Updated to https://helm.sh/docs/topics/chart_repository which is referenced in the README from https://github.com/helm/chartmuseum, which feels appropriate.