### PR TITLE
docs: fix the out of date chartmuseum chart repo

### DIFF
--- a/content/docs/how-to-run/helm-chart.md
+++ b/content/docs/how-to-run/helm-chart.md
@@ -12,8 +12,8 @@ You can also view it on [Kubeapps Hub](https://hub.kubeapps.com/charts/stable/ch
 
 To install:
 ```bash
-helm repo add stable https://kubernetes-charts.storage.googleapis.com
-helm install stable/chartmuseum
+helm repo add chartmuseum https://chartmuseum.github.io/charts
+helm install chartmuseum/chartmuseum
 ```
 
 If interested in making changes, please submit a PR to kubernetes/charts. Before doing any work, please check for any [currently open pull requests](https://github.com/kubernetes/charts/pulls?q=is%3Apr+is%3Aopen+chartmuseum). Thanks!


### PR DESCRIPTION
migrates the old chart repo path (googleapi) to the new home(chartmuseum.github.io).