### PR TITLE
fix: update cache info

### DIFF
--- a/content/docs/cache/_index.md
+++ b/content/docs/cache/_index.md
@@ -12,7 +12,7 @@ You may wish to offload this to an external cache store, especially for large, m
 
 ### Cache Interval
 
-When dealing with thousands of charts, you may experience latency with the default settings. This is because upon each request, the storage backend is scanned for changes compared to the cache.
+When dealing with thousands of charts, you may experience latency with the default settings.
 
 If you are ok with `index.yaml` being out-of-date for a fixed period of time, you can improve performance by using the `--cache-interval=<interval>` option.
 

--- a/content/docs/notes-on-index.yaml/_index.md
+++ b/content/docs/notes-on-index.yaml/_index.md
@@ -10,7 +10,7 @@ The repository index (index.yaml) is dynamically generated based on packages fou
 
 `GET /index.yaml` occurs when you run `helm repo add chartmuseum http://localhost:8080` or `helm repo update`.
 
-If you manually add/remove a .tgz package from storage, it will be immediately reflected in `GET /index.yaml`.
+If you manually add/remove a .tgz package from storage, it will **not** be immediately reflected in `GET /index.yaml`. See the [Cache Interval](../docs/#cache) section for more details on how to rebuild the index from storage on an interval.
 
 You are no longer required to maintain your own version of index.yaml using `helm repo index --merge`.
 


### PR DESCRIPTION
Just some small updates to make it more clear how the cache works with charts added directly to the backend storage.

Relates to https://github.com/helm/chartmuseum/issues/611