### PR TITLE
docs: update Docker image source from Docker Hub to Github Package Re…

### DIFF
--- a/content/docs/how-to-run/docker-image.md
+++ b/content/docs/how-to-run/docker-image.md
@@ -6,7 +6,7 @@ weight: 12
 draft: false
 ---
 
-Available via [Github Package Registry](https://github.com/helm/chartmuseum/pkgs/container/chartmuseum).
+Available via [GitHub Package Registry](https://github.com/helm/chartmuseum/pkgs/container/chartmuseum).
 
 Example usage (local storage):
 ```bash

--- a/content/docs/how-to-run/docker-image.md
+++ b/content/docs/how-to-run/docker-image.md
@@ -16,7 +16,7 @@ docker run --rm -it \
   -e STORAGE=local \
   -e STORAGE_LOCAL_ROOTDIR=/charts \
   -v $(pwd)/charts:/charts \
-  chartmuseum/chartmuseum:latest
+  ghcr.io/helm/chartmuseum:v0.16.3
 ```
 
 Example usage (S3):
@@ -30,5 +30,5 @@ docker run --rm -it \
   -e STORAGE_AMAZON_PREFIX="" \
   -e STORAGE_AMAZON_REGION="us-east-1" \
   -v ~/.aws:/root/.aws:ro \
-  chartmuseum/chartmuseum:latest
+  ghcr.io/helm/chartmuseum:v0.16.3
 ```

--- a/content/docs/how-to-run/docker-image.md
+++ b/content/docs/how-to-run/docker-image.md
@@ -6,7 +6,7 @@ weight: 12
 draft: false
 ---
 
-Available via [Docker Hub](https://hub.docker.com/r/chartmuseum/chartmuseum/).
+Available via [Github Package Registry](https://github.com/helm/chartmuseum/pkgs/container/chartmuseum).
 
 Example usage (local storage):
 ```bash


### PR DESCRIPTION
This pull request updates the documentation for the Docker image of `chartmuseum` to point to the correct container registry.

Documentation update:

* [`content/docs/how-to-run/docker-image.md`](diffhunk://#diff-eaf22ec54cef19532861542090fa1612eece51d1bb87f647eda8e321a7fe28bcL9-R9): Updated the link from Docker Hub to the GitHub Package Registry for the `chartmuseum` Docker image.